### PR TITLE
week11 - 브루트포스(재귀)

### DIFF
--- a/KimDohee/week11/스도쿠.js
+++ b/KimDohee/week11/스도쿠.js
@@ -1,0 +1,95 @@
+/**
+ * 스도쿠
+ * https://www.acmicpc.net/problem/2580
+ * 이 게임은 아래 그림과 같이 가로, 세로 각각 9개씩 총 81개의 작은 칸으로 이루어진 정사각형 판 위에서 이뤄지는데, 게임 시작 전 일부 칸에는 1부터 9까지의 숫자 중 하나가 쓰여 있다.
+ * 각각의 가로줄과 세로줄에는 1부터 9까지의 숫자가 한 번씩만 나타나야 한다.
+ * 굵은 선으로 구분되어 있는 3x3 정사각형 안에도 1부터 9까지의 숫자가 한 번씩만 나타나야 한다.
+ */
+
+function solution(input) {
+  const board = input.map(line => line.split(' ').map(Number));
+
+  // 행 검사 함수
+  function checkRow(board, row, num) {
+    for (let col = 0; col < 9; col++) {
+      // 이미 숫자가 같은 행에 존재할 경우 false 반환
+      if (board[row][col] === num) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // 열 검사 함수
+  function checkCol(board, col, num) {
+    for (let row = 0; row < 9; row++) {
+      // 이미 숫자가 같은 열에 존재할 경우 false 반환
+      if (board[row][col] === num) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // 3 * 3 박스 검사 함수
+  function checkBox(board, row, col, num) {
+    const startRow = Math.floor(row / 3) * 3;
+    const startCol = Math.floor(col / 3) * 3;
+
+    for (let i = 0; i < 3; i++) {
+      for (let j = 0; j < 3; j++) {
+        if (board[startRow + i][startCol + j] === num) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function dfs(board) {
+    // 빈칸 찾기
+    for (let row = 0; row < 9; row++) {
+      for (let col = 0; col < 9; col++) {
+        if (board[row][col] === 0) {
+          // 1~9까지 시도해보기
+          for (let num = 1; num <= 9; num++) {
+            if (checkRow(board, row, num) &&
+                checkCol(board, col, num) && 
+                checkBox(board, row, col, num)) {
+
+              // 유효하면 빈칸에 숫자를 대입
+              board[row][col] = num;
+
+              // 다음단계로 진행
+              if (dfs(board)) {
+                return true;  // 성공
+              }
+
+              // 실패하면 백트래킹
+              board[row][col] = 0;
+            }
+          }
+            
+          // 1~9 모두 안되면 실패
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+  dfs(board);
+
+  // 결과를 문자열로 만들어서 반환
+  const result = [];
+  for (let i = 0; i < 9; i++) {
+    result.push(board[i].join(' '));
+  }
+  return result.join('\n');
+}
+
+// 백준 제출용 코드
+const fs = require('fs');
+const filePath = process.platform === 'linux' ? '/dev/stdin' : 'input.txt';
+const input = fs.readFileSync(filePath).toString().trim().split('\n');
+
+console.log(solution(input));

--- a/KimDohee/week11/에너지모으기.js
+++ b/KimDohee/week11/에너지모으기.js
@@ -1,0 +1,40 @@
+/** 에너지 모으기
+ * https://www.acmicpc.net/problem/16198
+ * N개의 구슬이 일렬로 놓여져 있을 때 첫번째와 마지막 구슬을 제외한 구슬 중 x번째 구슬을 제거해서 모을 수 있는 에너지의 최댓값 
+ */
+
+function solution(input) {
+  const N = input.trim().split('\n')[0];
+  const weights = input.trim().split('\n')[1].split(' ').map(Number);  // 구슬 무게 배열
+
+  function dfs(weights) {
+    // 종료조건 - 구슬이 2개 남았을 때
+    if (weights.length === 2) return 0;
+
+    let max = 0;
+
+    // 첫번째와 마지막을 제외한 모든 구슬 시도
+    for (let i = 1; i < weights.length - 1; i++) {
+      // 에너지 계산
+      const energy = weights[i-1] * weights[i+1];
+
+      // 백트래킹 - 배열 복사후 구슬 제거
+      const newWeights = [...weights];
+      newWeights.splice(i, 1);  // 현재 구슬 제거
+
+      // 최댓값 갱신 (현재 에너지 + 남은 에너지)
+      max = Math.max(max, energy + dfs(newWeights));
+    }
+
+    return max;
+  }
+
+  return dfs(weights);
+}
+
+// 백준 제출용 코드
+const fs = require('fs');
+const filePath = process.platform === 'linux' ? '/dev/stdin' : 'input.txt';
+const input = fs.readFileSync(filePath).toString();
+
+console.log(solution(input));

--- a/KimDohee/week11/퇴사.js
+++ b/KimDohee/week11/퇴사.js
@@ -1,0 +1,47 @@
+/** 퇴사
+ * https://www.acmicpc.net/problem/14501
+ * 오늘부터 N+1일째 되는 날 퇴사를 하기 위해서, 남은 N일 동안 최대한 많은 상담을 하려고 한다.
+ * 각각의 상담은 상담을 완료하는데 걸리는 기간 Ti와 상담을 했을 때 받을 수 있는 금액 Pi로 이루어져 있다.
+ */
+
+function solution(input) {
+  const lines = input.trim().split('\n');
+  const N = parseInt(lines[0]);
+  const T = [0];  // 인덱스 0은 사용 안함
+  const P = [0];  // 인덱스 0은 사용 안함
+
+  for (let i = 1; i <= N; i++) {
+    const [t, p] = lines[i].split(' ').map(Number);
+    T.push(t);
+    P.push(p);
+  }
+
+  function dfs(day) {
+    // 종료 조건 - 퇴사일(N+1)에 도달하면 상담할 수 없음
+    if (day > N) return 0;
+
+    // 1. 현재 날짜 상담을 건너뛰는 경우
+    let profitSkip = dfs(day + 1);
+
+    // 2. 현재 날짜 상담을 선택하는 경우
+    let profitTake = 0;
+
+    if (day + T[day] - 1 <= N) {
+      // 현재 상담 수익 + 다음 상담부터의 최대 수익
+      profitTake = P[day] + dfs(day + T[day]);
+    }
+
+    // 더 큰 수익 반환
+    return Math.max(profitSkip, profitTake);
+  }
+
+  return dfs(1);  // 1일차부터 시작
+}
+
+
+// 백준 제출용 코드
+const fs = require('fs');
+const filePath = process.platform === 'linux' ? '/dev/stdin' : 'input.txt';
+const input = fs.readFileSync(filePath).toString();
+
+console.log(solution(input));


### PR DESCRIPTION
#39 
## 💻 문제 정보
1
- 문제 이름: 에너지 모으기
- 문제 링크: https://www.acmicpc.net/problem/16198 
- 난이도: 실버1
- 문제 요약: N개의 구슬이 일렬로 놓여져 있을 때 첫번째와 마지막 구슬을 제외한 구슬 중 x번째 구슬을 제거해서 모을 수 있는 에너지의 최댓값 

2
- 문제 이름: 퇴사
- 문제 링크: https://www.acmicpc.net/problem/14501
- 난이도: 실버3
- 문제 요약: 퇴사일 전까지 최대 수익을 얻을 수 있는 상담 계획 짜기

3
- 문제 이름: 스도쿠
- 문제 링크: https://www.acmicpc.net/problem/2580
- 난이도: 골드4
- 문제 요약: 스도쿠 빈칸을 완성하기

## 🔍 풀이 과정
1 - DFS, 백트래킹을 사용해서 모든 가능한 제거 순서를 시도
2 - DFS, 현재 날짜 상담을 선택하는 경우, 건너뛰는 경우 두가지로 나누어 최대수익 검토
3 - 행, 열, 박스 안에 같은 숫자가 들어가지 않도록 유효성 검사 후 DFS 실행

## 🚀 사용한 알고리즘/자료구조
- DFS, 백트래킹
